### PR TITLE
V2.2.3 bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tag-scanner"
-version = "2.2.2"
+version = "2.2.3"
 description = "This package provides a command line tool moles_esgf_tag to generate dataset tags for both MOLES and ESGF."
 license = "BSD 3"
 readme = "README.md"

--- a/tag_scanner/facets.py
+++ b/tag_scanner/facets.py
@@ -138,7 +138,7 @@ class Facets(object):
         self._reverse_facet_mappings(facet=BROADER_PROCESSING_LEVEL)
 
         self.__facets            = self._lower_all_facets(self.__facets)
-        self.__reversible_facets = self._lower_all_facets(self.__reversible_facets)
+        self.__reversible_facets = self._lower_all_facets(self.__reversible_facets, reverse=True)
 
         self.__facets = dict(sorted(self.__facets.items()))
         self.__reversible_facets = dict(sorted(self.__reversible_facets.items()))
@@ -543,7 +543,7 @@ class Facets(object):
                     mapping
                 ]
 
-    def _lower_all_facets(self, facets: dict) -> dict:
+    def _lower_all_facets(self, facets: dict, reverse: bool = False) -> dict:
         """
         Lower-case labels for all facet values."""
         new_facets = {}
@@ -551,6 +551,9 @@ class Facets(object):
         for facet, fset in facets.items():
             new_set = {}
             for label, lset in fset.items():
-                new_set[label.lower()] = lset
+                if reverse:
+                    new_set[label] = lset.lower()
+                else:
+                    new_set[label.lower()] = lset
             new_facets[facet] = new_set
         return new_facets


### PR DESCRIPTION
Fix being released in the v2.2.3 update:
 - Fixed the Drs issue: Caused by the `lower()` operation applied to reversible facet keys instead of values. The facet keys should all be lower-case, but the reversible facets are the other way around.